### PR TITLE
update buildkite jsonschema-dhall number and integer mappings to allow for dhall Integer types

### DIFF
--- a/out/definitions/automaticRetry/properties/exit_status/Schema
+++ b/out/definitions/automaticRetry/properties/exit_status/Schema
@@ -1,1 +1,1 @@
-< Number : Natural | String : Text >
+< Integer : Integer | String : Text >

--- a/out/definitions/automaticRetry/properties/exit_status/Type
+++ b/out/definitions/automaticRetry/properties/exit_status/Type
@@ -1,1 +1,1 @@
-< Number : Natural | String : Text >
+< Integer : Integer | String : Text >

--- a/out/definitions/automaticRetry/properties/limit/Schema
+++ b/out/definitions/automaticRetry/properties/limit/Schema
@@ -1,1 +1,1 @@
-Natural
+Integer

--- a/out/definitions/automaticRetry/properties/limit/Type
+++ b/out/definitions/automaticRetry/properties/limit/Type
@@ -1,1 +1,1 @@
-Natural
+Integer

--- a/out/definitions/commandStep/properties/concurrency/Schema
+++ b/out/definitions/commandStep/properties/concurrency/Schema
@@ -1,1 +1,1 @@
-Natural
+Integer

--- a/out/definitions/commandStep/properties/concurrency/Type
+++ b/out/definitions/commandStep/properties/concurrency/Type
@@ -1,1 +1,1 @@
-Natural
+Integer

--- a/out/definitions/commandStep/properties/parallelism/Schema
+++ b/out/definitions/commandStep/properties/parallelism/Schema
@@ -1,1 +1,1 @@
-Natural
+Integer

--- a/out/definitions/commandStep/properties/parallelism/Type
+++ b/out/definitions/commandStep/properties/parallelism/Type
@@ -1,1 +1,1 @@
-Natural
+Integer

--- a/out/definitions/commandStep/properties/timeout_in_minutes/Schema
+++ b/out/definitions/commandStep/properties/timeout_in_minutes/Schema
@@ -1,1 +1,1 @@
-Natural
+Integer

--- a/out/definitions/commandStep/properties/timeout_in_minutes/Type
+++ b/out/definitions/commandStep/properties/timeout_in_minutes/Type
@@ -1,1 +1,1 @@
-Natural
+Integer

--- a/schema.json
+++ b/schema.json
@@ -34,7 +34,7 @@
               ]
             },
             {
-              "type": "number"
+              "type": "integer"
             }
           ]
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,7 +741,6 @@ mod lambda_lift {
         fn go(ctx: &mut Context, typ: Rc<Type0>, new_vars: &mut Vec<VarRef>) -> Rc<Type0> {
             use Type0::*;
             match &*typ {
-                Bool | Text | Natural | Var(_) => typ,
                 Bool | Text | Natural | Integer | Var(_) => typ,
                 List(t_) => Rc::new(List(go(ctx, t_.clone(), new_vars))),
                 Optional(t_) => Rc::new(Optional(go(ctx, t_.clone(), new_vars))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,7 @@ pub enum Type0 {
     Bool,
     Text,
     Natural,
+    Integer,
     List(Rc<Type0>),
     Optional(Rc<Type0>),
     StringMap(Rc<Type0>),
@@ -205,6 +206,7 @@ impl Type0 {
             Type0::Bool => "Boolean".to_string(),
             Type0::Text => "String".to_string(),
             Type0::Natural => "Number".to_string(),
+            Type0::Integer => "Integer".to_string(),
             Type0::List(t_) => format!("List{}", t_.to_variant_name(ctx)),
             Type0::Optional(t_) => format!("Optional{}", t_.to_variant_name(ctx)),
             Type0::StringMap(t_) => format!("StringMap{}", t_.to_variant_name(ctx)),
@@ -234,6 +236,7 @@ impl Type0 {
             Type0::Bool => "Bool".to_string(),
             Type0::Text => "Text".to_string(),
             Type0::Natural => "Natural".to_string(),
+            Type0::Integer => "Integer".to_string(),
             Type0::List(t_) => format!("List {}", t_.pp()),
             Type0::Optional(t_) => format!("Optional {}", t_.pp()),
             Type0::StringMap(t_) => format!("List {{ mapKey: Text, mapValue: {} }}", t_.pp()),
@@ -739,6 +742,7 @@ mod lambda_lift {
             use Type0::*;
             match &*typ {
                 Bool | Text | Natural | Var(_) => typ,
+                Bool | Text | Natural | Integer | Var(_) => typ,
                 List(t_) => Rc::new(List(go(ctx, t_.clone(), new_vars))),
                 Optional(t_) => Rc::new(Optional(go(ctx, t_.clone(), new_vars))),
                 StringMap(t_) => Rc::new(StringMap(go(ctx, t_.clone(), new_vars))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -579,7 +579,8 @@ fn schemaToType(ctx: &mut Context, s: &SchemaObject) -> Type0 {
                 SingleOrVec::Single(it) => match it {
                     box InstanceType::Null => panic!("Unimplemented"),
                     box InstanceType::Boolean => Type0::Bool,
-                    box InstanceType::Number | box InstanceType::Integer => Type0::Natural,
+                    box InstanceType::Number => Type0::Natural,
+                    box InstanceType::Integer => Type0::Integer,
                     box InstanceType::String => Type0::Text,
                     box InstanceType::Array => {
                         let array = s.array.expect("Array has array field");


### PR DESCRIPTION
There are Buildkite pipeline properties (e.g. **automaticRetry::exit_status**) which expect a signed numerical value or Integer type in dhall; though, currently during conversion all Buildkite jsonschema numerical types (`number` & `integer`) are mapped to Natural, unsigned numeric types in Dhall.

This change adds an `integer`(jsonschema) -> `Integer`(Dhall) mapping to allow for this type of Integer expression.